### PR TITLE
switch to using jQuery; refactor jQuery var into const

### DIFF
--- a/lib/action_view/helpers/jquery_helper.rb
+++ b/lib/action_view/helpers/jquery_helper.rb
@@ -97,10 +97,6 @@ module ActionView
     module JqueryHelper
       USE_PROTECTION = const_defined?(:DISABLE_JQUERY_FORGERY_PROTECTION) ? !DISABLE_JQUERY_FORGERY_PROTECTION : true
 
-      unless const_defined? :JQUERY_VAR
-        JQUERY_VAR = 'jQuery'
-      end
-
       unless const_defined? :JQCALLBACKS
         JQCALLBACKS = Set.new([ :beforeSend, :complete, :error, :success ] + (100..599).to_a)
         #instance_eval { remove_const :AJAX_OPTIONS }
@@ -134,7 +130,7 @@ module ActionView
           update << "'#{options[:update]}'"
         end
 
-        function = "$.ajax(#{javascript_options})"
+        function = "#{JQUERY_VAR}.ajax(#{javascript_options})"
 
         function = "#{options[:before]}; #{function}" if options[:before]
         function = "#{function}; #{options[:after]}"  if options[:after]
@@ -326,7 +322,7 @@ module ActionView
             insertion = position.to_s.downcase
             insertion = 'append' if insertion == 'bottom'
             insertion = 'prepend' if insertion == 'top'
-            call "$(\"#{jquery_id(id)}\").#{insertion}", render(*options_for_render)
+            call "#{JQUERY_VAR}(\"#{jquery_id(id)}\").#{insertion}", render(*options_for_render)
             # content = javascript_object_for(render(*options_for_render))
             # record "Element.insert(\"#{id}\", { #{position.to_s.downcase}: #{content} });"
           end
@@ -342,7 +338,7 @@ module ActionView
           #   page.replace_html 'person-45', :partial => 'person', :object => @person
           #
           def replace_html(id, *options_for_render)
-            call "$(\"#{jquery_id(id)}\").html", render(*options_for_render)
+            call "#{JQUERY_VAR}(\"#{jquery_id(id)}\").html", render(*options_for_render)
             # call 'Element.update', id, render(*options_for_render)
           end
 
@@ -377,7 +373,7 @@ module ActionView
           #   page.replace 'person_45', :partial => 'person', :object => @person
           #
           def replace(id, *options_for_render)
-            call "$(\"#{jquery_id(id)}\").replaceWith", render(*options_for_render)
+            call "#{JQUERY_VAR}(\"#{jquery_id(id)}\").replaceWith", render(*options_for_render)
             #call 'Element.replace', id, render(*options_for_render)
           end
 
@@ -390,7 +386,7 @@ module ActionView
           #  page.remove 'person_23', 'person_9', 'person_2'
           #
           def remove(*ids)
-            call "$(\"#{jquery_ids(ids)}\").remove"
+            call "#{JQUERY_VAR}(\"#{jquery_ids(ids)}\").remove"
             #loop_on_multiple_args 'Element.remove', ids
           end
 
@@ -403,7 +399,7 @@ module ActionView
           #  page.show 'person_6', 'person_13', 'person_223'
           #
           def show(*ids)
-            call "$(\"#{jquery_ids(ids)}\").show"
+            call "#{JQUERY_VAR}(\"#{jquery_ids(ids)}\").show"
             #loop_on_multiple_args 'Element.show', ids
           end
 
@@ -416,7 +412,7 @@ module ActionView
           #  page.hide 'person_29', 'person_9', 'person_0'
           #
           def hide(*ids)
-            call "$(\"#{jquery_ids(ids)}\").hide"
+            call "#{JQUERY_VAR}(\"#{jquery_ids(ids)}\").hide"
             #loop_on_multiple_args 'Element.hide', ids
           end
 
@@ -429,7 +425,7 @@ module ActionView
           #  page.toggle 'person_14', 'person_12', 'person_23'      # Shows the previously hidden elements
           #
           def toggle(*ids)
-            call "$(\"#{jquery_ids(ids)}\").toggle"
+            call "#{JQUERY_VAR}(\"#{jquery_ids(ids)}\").toggle"
             #loop_on_multiple_args 'Element.toggle', ids
           end
 
@@ -639,11 +635,11 @@ module ActionView
           js_options['dataType'] = options[:datatype] ? "'#{options[:datatype]}'" : (options[:update] ? nil : "'script'")
 
           if options[:form]
-            js_options['data'] = "$.param($(this).serializeArray())"
+            js_options['data'] = "#{JQUERY_VAR}.param(#{JQUERY_VAR}(this).serializeArray())"
           elsif options[:submit]
-            js_options['data'] = "i$(\"##{options[:submit]} :input\").serialize()"
+            js_options['data'] = "#{JQUERY_VAR}(\"##{options[:submit]} :input\").serialize()"
           elsif options[:with]
-            js_options['data'] = options[:with].gsub("Form.serialize(this.form)","i$.param(i$(this.form).serializeArray())")
+            js_options['data'] = options[:with].gsub("Form.serialize(this.form)","#{JQUERY_VAR}.param(#{JQUERY_VAR}(this.form).serializeArray())")
           end
 
           js_options['type'] ||= "'post'"
@@ -767,7 +763,7 @@ module ActionView
       def initialize(generator, id)
         id = id.to_s.count('#.*,>+~:[/ ') == 0 ? "##{id}" : id
         @id = id
-        super(generator, "$(#{::ActiveSupport::JSON.encode(id)})".html_safe)
+        super(generator, "#{JQUERY_VAR}(#{::ActiveSupport::JSON.encode(id)})".html_safe)
       end
 
       # Allows access of element attributes through +attribute+. Examples:
@@ -932,7 +928,7 @@ module ActionView
 
     class JavaScriptElementCollectionProxy < JavaScriptCollectionProxy #:nodoc:\
       def initialize(generator, pattern)
-        super(generator, "$(#{::ActiveSupport::JSON.encode(pattern)})")
+        super(generator, "#{JQUERY_VAR}(#{::ActiveSupport::JSON.encode(pattern)})")
       end
     end
   end

--- a/lib/action_view/helpers/jquery_ui_helper.rb
+++ b/lib/action_view/helpers/jquery_ui_helper.rb
@@ -97,7 +97,7 @@ module ActionView
         #if ['fadeIn','fadeOut','fadeToggle'].include?(name)
         #  "$(\"#{jquery_id(element_id)}\").#{name}();"
         #else
-          "$(#{element}).#{mode || "effect"}(\"#{name}\",#{options_for_javascript(js_options)});"
+          "#{JQUERY_VAR}(#{element}).#{mode || "effect"}(\"#{name}\",#{options_for_javascript(js_options)});"
         #end
 
       end
@@ -205,10 +205,10 @@ module ActionView
         
         if options[:onUpdate] || options[:url]
           if options[:format]
-            options[:with] ||= "$(this).sortable('serialize',{key:'#{element_id}[]', expression:#{options[:format]}})"
+            options[:with] ||= "#{JQUERY_VAR}(this).sortable('serialize',{key:'#{element_id}[]', expression:#{options[:format]}})"
             options.delete(:format)
           else
-            options[:with] ||= "$(this).sortable('serialize',{key:'#{element_id}[]'})"
+            options[:with] ||= "#{JQUERY_VAR}(this).sortable('serialize',{key:'#{element_id}[]'})"
           end
           
           options[:onUpdate] ||= "function(){" + remote_function(options) + "}"
@@ -223,7 +223,7 @@ module ActionView
         
         options[:connectWith] = array_or_string_for_javascript(options[:connectWith]) if options[:connectWith]
         
-        %($('#{jquery_id(element_id)}').sortable(#{options_for_javascript(options)});)
+        %(#{JQUERY_VAR}('#{jquery_id(element_id)}').sortable(#{options_for_javascript(options)});)
       end
 
       # Makes the element with the DOM ID specified by +element_id+ draggable.

--- a/lib/jquery-rjs.rb
+++ b/lib/jquery-rjs.rb
@@ -1,6 +1,10 @@
 require 'rails'
 require 'active_support'
 
+unless defined? JQUERY_VAR
+  JQUERY_VAR = 'jQuery'
+end
+
 module JqueryRjs
   class Engine < Rails::Engine
     initializer 'jquery-rjs.initialize' do


### PR DESCRIPTION
I needed this because we have Prototype installed still but we can't get rid of it that fast. For the moment, we need jQuery to be accessed using `jQuery` and not `$`.

I could use some help determining where best to initialize `JQUERY_VAR`. Right now it will be defined when the gem/bundle gets loaded.

Also--are you concerned about tests for this repo? Lots of (seemingly old) failures, so I didn't fix anything.
