### PR TITLE
Don't set the axis if no constraint is chosen

### DIFF
--- a/lib/action_view/helpers/jquery_ui_helper.rb
+++ b/lib/action_view/helpers/jquery_ui_helper.rb
@@ -194,10 +194,8 @@ module ActionView
             "y"
           when "horizontal", :horizontal
             "x"
-          when false
+          else
             nil
-          when nil
-            "y"
         end
         options.delete(:axis) if options[:axis].nil?
         options.delete(:overlap)


### PR DESCRIPTION
The axis setting messes up the smart defaults set by jQuery UI Sortable.

Try it out on a horizontal list. It breaks without my patch.
