### PR TITLE
Remote function should not have html_safe()

### DIFF
--- a/lib/action_view/helpers/jquery_helper.rb
+++ b/lib/action_view/helpers/jquery_helper.rb
@@ -136,7 +136,7 @@ module ActionView
         function = "#{function}; #{options[:after]}"  if options[:after]
         function = "if (#{options[:condition]}) { #{function}; }" if options[:condition]
         function = "if (confirm('#{escape_javascript(options[:confirm])}')) { #{function}; }" if options[:confirm]
-        return function.html_safe
+        return function
       end
 
       # All the methods were moved to GeneratorMethods so that


### PR DESCRIPTION
The function returns javascript, not HTML code so escaping it can cause errors when the JS uses both type of quotes.
https://github.com/ManageIQ/manageiq/issues/3876
